### PR TITLE
Fixed XFEATURES2D namespace.

### DIFF
--- a/map_merge/src/combine_grids/estimation_internal.h
+++ b/map_merge/src/combine_grids/estimation_internal.h
@@ -65,7 +65,7 @@ static inline cv::Ptr<cv::Feature2D> chooseFeatureFinder(FeatureType type)
       return cv::ORB::create();
     case FeatureType::SURF:
 #ifdef HAVE_OPENCV_XFEATURES2D
-      return xfeatures2d::SURF::create();
+      return cv::xfeatures2d::SURF::create();
 #else
       return cv::AKAZE::create();
 #endif


### PR DESCRIPTION
The XFEATURES2D module has namespace `cv::xfeatures2d`, not just `xfeatures2d`.